### PR TITLE
Improve batching, augmentation, and robustness across DANNCE pipeline and multi-GPU submission

### DIFF
--- a/cluster/multi_gpu.py
+++ b/cluster/multi_gpu.py
@@ -276,10 +276,10 @@ class MultiGpuHandler:
             List: Batch parameters list of dictionaries.
         """
         start_samples = np.arange(0, n_samples, self.n_samples_per_gpu, dtype=int)
-        max_samples = start_samples + self.n_samples_per_gpu
+        batch_sizes = np.minimum(self.n_samples_per_gpu, n_samples - start_samples)
         batch_params = [
-            {"start_sample": sb, "max_num_samples": self.n_samples_per_gpu}
-            for sb, mb in zip(start_samples, max_samples)
+            {"start_sample": sb, "max_num_samples": bs}
+            for sb, bs in zip(start_samples, batch_sizes)
         ]
 
         if self.only_unfinished:
@@ -299,7 +299,7 @@ class MultiGpuHandler:
             pred_files = [
                 f for f in pred_files if not f.endswith(COM_BASE_NAME + ".mat")
             ]
-            if len(pred_files) > 1:
+            if len(pred_files) > 0:
                 params = load_params(self.config)
                 pred_ids = [int(f.split(".")[0].split("3d")[1]) for f in pred_files]
                 for i, batch_param in reversed(list(enumerate(batch_params))):
@@ -320,8 +320,7 @@ class MultiGpuHandler:
             List: Batch parameters list of dictionaries.
         """
         start_samples = np.arange(0, n_samples, self.n_samples_per_gpu, dtype=int)
-        max_samples = start_samples + self.n_samples_per_gpu
-        max_samples[-1] = n_samples
+        batch_sizes = np.minimum(self.n_samples_per_gpu, n_samples - start_samples)
 
         params = load_params(self.config)
         params = {**params, **load_params("io.yaml")}
@@ -335,11 +334,11 @@ class MultiGpuHandler:
             # for n_instance in range(params["n_instances"]):
             dannce_predict_dir = os.path.join(params["dannce_predict_dir"])
             os.makedirs(dannce_predict_dir, exist_ok=True)
-            for sb, mb in zip(start_samples, max_samples):
+            for sb, bs in zip(start_samples, batch_sizes):
                 batch_params.append(
                     {
                         "start_sample": sb,
-                        "max_num_samples": mb,
+                        "max_num_samples": bs,
                         "com_file": com_file,
                         "dannce_predict_dir": dannce_predict_dir,
                         "batch_size": 1,  # Set the batch size to 1 for multi-instance to avoid memory issues
@@ -350,8 +349,8 @@ class MultiGpuHandler:
                 batch_params = self.remove_finished_batches_multi_instance(batch_params)
         else:
             batch_params = [
-                {"start_sample": sb, "max_num_samples": mb}
-                for sb, mb in zip(start_samples, max_samples)
+                {"start_sample": sb, "max_num_samples": bs}
+                for sb, bs in zip(start_samples, batch_sizes)
             ]
 
             # Delete batch_params that were already finished
@@ -373,16 +372,21 @@ class MultiGpuHandler:
         print(dannce_predict_dirs)
         # For each instance directory, find the completed batches and delete the params.
         for pred_dir in dannce_predict_dirs:
+            if not os.path.exists(pred_dir):
+                continue
+
             # Get all of the files
             pred_files = [f for f in os.listdir(pred_dir) if DANNCE_BASE_NAME in f]
 
             # Remove any of the default merged files.
             pred_files = [f for f in pred_files if f != (DANNCE_BASE_NAME + ".mat")]
             pred_files = [f for f in pred_files if "init" not in f]
-            if len(pred_files) > 1:
+            if len(pred_files) > 0:
                 params = load_params(self.config)
-                if "batch_size" in batch_params:
-                    params["batch_size"] = batch_params["batch_size"]
+                if len(batch_params) > 0:
+                    params["batch_size"] = batch_params[0].get(
+                        "batch_size", params.get("batch_size", 1)
+                    )
                 pred_ids = [
                     int(f.split(".")[0].split("AVG")[1]) * params["batch_size"]
                     for f in pred_files
@@ -420,7 +424,8 @@ class MultiGpuHandler:
 
         # Remove any of the default merged files.
         pred_files = [f for f in pred_files if f != (DANNCE_BASE_NAME + ".mat")]
-        if len(pred_files) > 1:
+        pred_files = [f for f in pred_files if "init" not in f]
+        if len(pred_files) > 0:
             params = load_params(self.config)
             pred_ids = [
                 int(f.split(".")[0].split("AVG")[1]) * params["batch_size"]
@@ -459,13 +464,16 @@ class MultiGpuHandler:
         batch_params = self.generate_batch_params_dannce(n_samples)
         slurm_config = load_params(load_params(self.config)["slurm_config"])
 
-        cmd = f"""sbatch --array=0-{len(batch_params) - 1} {slurm_config["dannce_multi_predict"]} --wrap="{slurm_config["setup"]} dannce-predict-single-batch {self.config}"""
+        cmd = None
+        job_id = None
         if len(batch_params) > 0:
+            cmd = f"""sbatch --array=0-{len(batch_params) - 1} {slurm_config["dannce_multi_predict"]} --wrap="{slurm_config["setup"]} dannce-predict-single-batch {self.config}"""
             self.save_batch_params(batch_params)
             job_id = self.submit_jobs(batch_params, cmd)
-            return job_id
-        else:
-            return None
+
+        if self.test:
+            return batch_params, cmd
+        return job_id
 
     def submit_sdannce_predict_multi_gpu(self):
         """Predict dannce over multiple gpus in parallel.
@@ -500,14 +508,16 @@ class MultiGpuHandler:
         batch_params = self.generate_batch_params_com(n_samples)
         slurm_config = load_params(load_params(self.config)["slurm_config"])
 
-        cmd = f"""sbatch --array=0-{len(batch_params) - 1} {slurm_config["com_multi_predict"]} --wrap='{slurm_config["setup"]} com-predict-single-batch {self.config}'"""
-
+        cmd = None
+        job_id = None
         if len(batch_params) > 0:
+            cmd = f"""sbatch --array=0-{len(batch_params) - 1} {slurm_config["com_multi_predict"]} --wrap='{slurm_config["setup"]} com-predict-single-batch {self.config}'"""
             self.save_batch_params(batch_params)
             job_id = self.submit_jobs(batch_params, cmd)
-            return job_id
-        else:
-            return None
+
+        if self.test:
+            return batch_params, cmd
+        return job_id
 
     def com_merge(self):
         """Merge com chunks into a single file.
@@ -750,7 +760,8 @@ def inference():
         args["com_config"], only_unfinished=True, test=args["test"]
     )
     for _ in range(MAX_N_RETRIES):
-        job_id = handler.submit_com_predict_multi_gpu()
+        submission = handler.submit_com_predict_multi_gpu()
+        job_id = submission if not isinstance(submission, tuple) else None
         wait_for_job(job_id)
 
     if args["test"]:
@@ -762,7 +773,8 @@ def inference():
         args["dannce_config"], only_unfinished=True, test=args["test"]
     )
     for _ in range(MAX_N_RETRIES):
-        job_id = handler.submit_dannce_predict_multi_gpu()
+        submission = handler.submit_dannce_predict_multi_gpu()
+        job_id = submission if not isinstance(submission, tuple) else None
         wait_for_job(job_id)
     if args["test"]:
         print("Skipping dannce merge during test.")
@@ -820,7 +832,8 @@ def sdannce_inference():
         args["com_config"], only_unfinished=True, test=args["test"]
     )
     for _ in range(MAX_N_RETRIES):
-        job_id = handler.submit_com_predict_multi_gpu()
+        submission = handler.submit_com_predict_multi_gpu()
+        job_id = submission if not isinstance(submission, tuple) else None
         wait_for_job(job_id)
 
     if args["test"]:

--- a/dannce/__init__.py
+++ b/dannce/__init__.py
@@ -256,6 +256,7 @@ class COMAugmentation:
     augment_rotation: bool = False
     augment_shear: bool = False
     augment_zoom: bool = False
+    augment_shift: bool = False
     augment_shear_val: int = 5
     augment_zoom_val: float = 0.05
     augment_shift_val: float = 0.05

--- a/dannce/engine/data/dataset.py
+++ b/dannce/engine/data/dataset.py
@@ -347,16 +347,33 @@ class PoseDatasetFromMem(torch.utils.data.Dataset):
         """
         # torchvision.transforms.functional.affine - input: [..., H, W]
         rotangle = np.random.rand() * (2 * max_delta) - max_delta
-        X = (
-            torch.from_numpy(X).reshape(*X.shape[:3], -1).permute(0, 3, 1, 2)
-        )  # dimension [B, D*C, H, W]
-        y_3d = torch.from_numpy(y_3d).reshape(y_3d.shape[:3], -1).permute(0, 3, 1, 2)
-        for i in range(X.shape[0]):
-            X[i] = TF.affine(X[i], angle=rotangle)
-            y_3d[i] = TF.affine(y_3d[i], angle=rotangle)
+        X_shape = X.shape
+        y_3d_shape = y_3d.shape
 
-        X = X.permute(0, 2, 3, 1).reshape(*X.shape[:3], X.shape[2], -1).numpy()
-        y_3d = y_3d.permute(0, 2, 3, 1).reshape(*X.shape[:3], X.shape[2], -1).numpy()
+        X = torch.from_numpy(X).reshape(*X_shape[:3], -1).permute(
+            0, 3, 1, 2
+        )  # dimension [B, D*C, H, W]
+        y_3d = torch.from_numpy(y_3d).reshape(*y_3d_shape[:3], -1).permute(0, 3, 1, 2)
+        for i in range(X.shape[0]):
+            X[i] = TF.affine(
+                X[i],
+                angle=rotangle,
+                translate=[0, 0],
+                scale=1.0,
+                shear=[0.0, 0.0],
+                interpolation=transforms.InterpolationMode.BILINEAR,
+            )
+            y_3d[i] = TF.affine(
+                y_3d[i],
+                angle=rotangle,
+                translate=[0, 0],
+                scale=1.0,
+                shear=[0.0, 0.0],
+                interpolation=transforms.InterpolationMode.BILINEAR,
+            )
+
+        X = X.permute(0, 2, 3, 1).reshape(*X_shape).numpy()
+        y_3d = y_3d.permute(0, 2, 3, 1).reshape(*y_3d_shape).numpy()
 
         return X, y_3d
 
@@ -982,6 +999,21 @@ class COMDatasetFromMem(torch.utils.data.Dataset):
         self.shear_val = shear_val
         self.zoom_val = zoom_val
 
+        self.list_IDs = self._group_list_ids(self.list_IDs)
+
+    def _group_list_ids(self, list_IDs):
+        if len(list_IDs) == 0:
+            return []
+
+        first_item = list_IDs[0]
+        if np.isscalar(first_item):
+            return [
+                np.asarray(list_IDs[i : i + self.batch_size])
+                for i in range(0, len(list_IDs), self.batch_size)
+            ]
+
+        return [np.asarray(ids) for ids in list_IDs]
+
     def __len__(self):
         return len(self.list_IDs)
 
@@ -1024,7 +1056,7 @@ class COMDatasetFromMem(torch.utils.data.Dataset):
         return X, y_2d
 
     def __getitem__(self, index):
-        list_IDs_temp = [self.list_IDs[index]]
+        list_IDs_temp = self.list_IDs[index]
         X, y = self.__data_generation(list_IDs_temp)
 
         return X, y
@@ -1033,8 +1065,9 @@ class COMDatasetFromMem(torch.utils.data.Dataset):
         """Generate data containing batch_size samples."""
         # Initialization
 
-        X = np.zeros((self.batch_size, *self.data.shape[1:]))
-        y_2d = np.zeros((self.batch_size, *self.labels.shape[1:]))
+        n_ids = len(list_IDs_temp)
+        X = np.zeros((n_ids, *self.data.shape[1:]), dtype=self.data.dtype)
+        y_2d = np.zeros((n_ids, *self.labels.shape[1:]), dtype=self.labels.dtype)
 
         for i, ID in enumerate(list_IDs_temp):
             X[i] = self.data[ID].copy()
@@ -1056,20 +1089,36 @@ class COMDatasetFromMem(torch.utils.data.Dataset):
             # TODO: replace with torchvision.transforms
             if self.augment_rotation:
                 affine["rotation"] = self.rotation_val * (np.random.rand() * 2 - 1)
-            # if self.augment_zoom:
-            #     affine["zoom"] = self.zoom_val * (np.random.rand() * 2 - 1) + 1
+            if self.augment_zoom:
+                affine["zoom"] = self.zoom_val * (np.random.rand() * 2 - 1) + 1
             if self.augment_shear:
                 affine["shear"] = self.shear_val * (np.random.rand() * 2 - 1)
 
+            X = torch.from_numpy(X).permute(0, 3, 1, 2).float()
+            y_2d = torch.from_numpy(y_2d).permute(0, 3, 1, 2).float()
+
             X = TF.affine(
-                torch.from_numpy(X).permute(0, 3, 1, 2),
+                X,
                 angle=affine["rotation"],
-                shear=affine["shear"],
+                translate=[0, 0],
+                scale=affine["zoom"],
+                shear=[affine["shear"], 0.0],
+                interpolation=transforms.InterpolationMode.BILINEAR,
             )
             y_2d = TF.affine(
-                torch.from_numpy(y_2d).permute(0, 3, 1, 2),
+                y_2d,
                 angle=affine["rotation"],
-                shear=affine["shear"],
+                translate=[0, 0],
+                scale=affine["zoom"],
+                shear=[affine["shear"], 0.0],
+                interpolation=transforms.InterpolationMode.BILINEAR,
+            )
+
+            X = X.permute(0, 2, 3, 1).numpy().astype(self.data.dtype, copy=False)
+            y_2d = (
+                y_2d.permute(0, 2, 3, 1)
+                .numpy()
+                .astype(self.labels.dtype, copy=False)
             )
 
         if self.augment_shift:

--- a/dannce/engine/data/processing.py
+++ b/dannce/engine/data/processing.py
@@ -260,6 +260,8 @@ def load_all_com_exps(params: Dict, exps: List):
     camnames = {}
     datadict = {}
     datadict_3d = {}
+    com3d_dict = {}
+    temporal_chunks = {}
     samples = []
     for e, expdict in enumerate(exps):
 
@@ -298,7 +300,16 @@ def load_all_com_exps(params: Dict, exps: List):
 
     samples = np.array(samples)
 
-    return samples, datadict, datadict_3d, com3d_dict, cameras, camnames, total_chunks, temporal_chunks
+    return (
+        samples,
+        datadict,
+        datadict_3d,
+        com3d_dict,
+        cameras,
+        camnames,
+        total_chunks,
+        temporal_chunks,
+    )
 
 
 def do_COM_load(exp: Dict, expdict: Dict, e, params: Dict, training=True):
@@ -566,7 +577,8 @@ def make_data_splits(
 
                 new_train_chunks = []
                 for chunk in train_chunks:
-                    if chunk[2] not in train_samples_to_be_removed:
+                    chunk_center = chunk[len(chunk) // 2]
+                    if chunk_center not in train_samples_to_be_removed:
                         new_train_chunks.append(chunk)
                 train_chunks = new_train_chunks
 

--- a/dannce/engine/data/serve_data_DANNCE.py
+++ b/dannce/engine/data/serve_data_DANNCE.py
@@ -239,6 +239,9 @@ def get_chunks(
 
         chunk_ind_list.append(chunk)
 
+    if len(chunk_ind_list) == 0:
+        return np.array([], dtype=int)
+
     all_samples_inds = np.concatenate(chunk_ind_list).astype(int)
     return all_samples_inds
 
@@ -297,19 +300,42 @@ def prepare_temporal_seqs(params, samples, labels, valid=False, support=False):
     # select extra samples from the neighborhood of labeled samples
     # each of which is referred as a "temporal chunk"
     left_bound, right_bound = get_seq_bounds(temp_n)
+    downsample = params.get("downsample", 1)
+
+    def _clip_request_size(requested, available, context):
+        if requested is None:
+            return 0
+        requested = int(requested)
+        if requested <= 0 or available <= 0:
+            return 0
+        clipped = min(requested, available)
+        if clipped < requested:
+            logger.warning(
+                "Requested {} temporal chunks for {}, but only {} are available. "
+                "Clipping request.".format(requested, context, clipped)
+            )
+        return clipped
+
+    valid_support_inds = np.arange(
+        max(0, -left_bound * downsample),
+        max(0, len(samples_extra) - max(0, (right_bound - 1) * downsample)),
+        max(1, temp_n * downsample),
+    )
 
     # what if we want to use the unlabeled frames in the test set for pretraining
     sample_inds, samples_inds_unlabeled, samples_test_inds = [], [], []
     if (support) and isinstance(params["n_support_chunks"], int):
-        samples_test_inds = np.random.choice(
-            samples_extra[-left_bound::temp_n],
-            size=params["n_support_chunks"],
-            replace=False,
+        n_support_chunks = _clip_request_size(
+            params["n_support_chunks"], len(valid_support_inds), "support pretraining"
         )
-        samples_test_inds = sorted(list(samples_test_inds))
+        if n_support_chunks > 0:
+            samples_test_inds = np.random.choice(
+                valid_support_inds, size=n_support_chunks, replace=False,
+            )
+            samples_test_inds = sorted(list(samples_test_inds))
         logger.info(
             "For unsupervised training, load in {} unlabeled chunks from the valid/test recording.".format(
-                params["n_support_chunks"]
+                n_support_chunks
             )
         )
         samples = None
@@ -324,19 +350,27 @@ def prepare_temporal_seqs(params, samples, labels, valid=False, support=False):
                 list(set(np.arange(len(samples_extra))) - set(sample_inds))
             )
             # n_unlabeled_temp = int(params["unlabeled_temp"])
-            n_unlabeled_temp = int(np.ceil(len(samples) * params["unlabeled_temp"]))
+            n_unlabeled_temp = _clip_request_size(
+                int(np.ceil(len(samples) * params["unlabeled_temp"])),
+                len(all_samples_inds_unlabeled),
+                "unlabeled temporal training",
+            )
             logger.info(
                 "Load in {} unlabeled temporal chunks, in addition to {} labels.".format(
                     n_unlabeled_temp, len(samples)
                 )
             )
-            samples_inds_unlabeled = np.random.choice(
-                all_samples_inds_unlabeled, size=n_unlabeled_temp, replace=False
-            )
-            samples_inds_unlabeled = sorted(list(samples_inds_unlabeled))
+            if n_unlabeled_temp > 0:
+                samples_inds_unlabeled = np.random.choice(
+                    all_samples_inds_unlabeled, size=n_unlabeled_temp, replace=False
+                )
+                samples_inds_unlabeled = sorted(list(samples_inds_unlabeled))
 
     sample_inds = sample_inds + samples_inds_unlabeled + samples_test_inds
     sample_inds = np.array(sample_inds)
+
+    if len(sample_inds) == 0:
+        return np.array([], dtype=samples_extra.dtype), labels, []
 
     # generate chunks
     all_samples_inds = get_chunks(
@@ -344,7 +378,7 @@ def prepare_temporal_seqs(params, samples, labels, valid=False, support=False):
         left_bound,
         right_bound,
         len(samples_extra),
-        downsample=params.get("downsample", 1),
+        downsample=downsample,
     )
 
     # there can be repetitive sampleIDs,
@@ -354,7 +388,9 @@ def prepare_temporal_seqs(params, samples, labels, valid=False, support=False):
     chunk_list = [
         all_samples[i : i + temp_n] for i in range(0, len(all_samples), temp_n)
     ]
-    all_samples, unique_index = np.unique(all_samples, return_index=True)
+    _, unique_index = np.unique(all_samples, return_index=True)
+    unique_index = np.sort(unique_index)
+    all_samples = all_samples[unique_index]
     labeled_inds = (
         np.array([np.where(all_samples == samp)[0][0] for samp in samples])
         if samples is not None
@@ -766,9 +802,10 @@ def prepend_experiment(
     """
     cameras_ = {}
     datadict_ = {}
-    new_chunks = {}
+    all_chunks = {}
     prev_camnames = camnames.copy()
     for e in range(num_experiments):
+        exp_chunks = {}
 
         # Create a unique camname for each camera in each experiment
         cameras_[e] = {}
@@ -781,14 +818,17 @@ def prepend_experiment(
         for n_cam, name in enumerate(camnames[e]):
             if dannce_prediction:
                 try:
-                    new_chunks[name] = params["experiment"][e]["chunks"][
+                    exp_chunks[name] = params["experiment"][e]["chunks"][
                         prev_camnames[e][n_cam]
                     ]
                 except:
-                    new_chunks[name] = params["experiment"][e]["chunks"][name]
+                    exp_chunks[name] = params["experiment"][e]["chunks"][name]
             else:
-                new_chunks[name] = params["experiment"][e]["chunks"][name]
-        params["experiment"][e]["chunks"] = new_chunks
+                exp_chunks[name] = params["experiment"][e]["chunks"][name]
+        params["experiment"][e]["chunks"] = exp_chunks
+        all_chunks.update(exp_chunks)
+
+    params["chunks"] = all_chunks
 
     for key in datadict.keys():
         enum = key.split("_")[0]

--- a/dannce/engine/models/loss.py
+++ b/dannce/engine/models/loss.py
@@ -33,9 +33,7 @@ def compute_mask_nan_loss(loss_fcn, kpts_gt, kpts_pred):
     valid_gt = kpts_gt[notnan_gt]
     valid_pred = kpts_pred[notnan_gt]
     
-    # Compute loss using mean reduction for better gradient flow
-    loss = torch.nn.functional.l1_loss(valid_pred, valid_gt, reduction='mean')
-    return loss
+    return loss_fcn(valid_gt, valid_pred)
 
 
 ##################################################################################################
@@ -290,14 +288,39 @@ class ConsistencyLoss(BaseLoss):
         self.copies_per_sample = copies_per_sample
 
     def forward(self, kpts_gt, kpts_pred):
-        if self.copies_per_sample <= kpts_pred.shape[0]:
+        if self.copies_per_sample < 2:
+            return kpts_pred.sum() * 0
+
+        batch_size = kpts_pred.shape[0]
+        can_group = (
+            batch_size >= self.copies_per_sample
+            and batch_size % self.copies_per_sample == 0
+        )
+
+        if can_group and kpts_gt is not None and kpts_gt.shape[0] == batch_size:
+            kpts_gt_grouped = kpts_gt.reshape(
+                -1, self.copies_per_sample, *kpts_gt.shape[1:]
+            )
+            can_group = bool(
+                torch.all(
+                    torch.isclose(
+                        kpts_gt_grouped[:, 1:],
+                        kpts_gt_grouped[:, :-1],
+                        equal_nan=True,
+                    )
+                )
+            )
+
+        if can_group:
             kpts_pred = kpts_pred.reshape(
                 -1, self.copies_per_sample, *kpts_pred.shape[1:]
             )
         else:
-            # validation
             kpts_pred = kpts_pred.unsqueeze(0)
+
         diff = torch.diff(kpts_pred, dim=1)
+        if diff.numel() == 0:
+            return kpts_pred.sum() * 0
         if self.method == "l1":
             loss_temp = torch.abs(diff).mean()
         else:

--- a/dannce/engine/run/data.py
+++ b/dannce/engine/run/data.py
@@ -1189,6 +1189,8 @@ def make_dataset_inference(params, valid_params):
         vids = {}
         for e in range(num_experiments):
             vids = processing.initialize_vids(params, datadict, e, vids, pathonly=True)
+    else:
+        vids = {}
 
     # Parameters
     valid_params = {
@@ -1244,9 +1246,11 @@ def make_dataset_inference(params, valid_params):
         params["write_visual_hull"] is not None
     ):
         # require silhouette + RGB volume
-        vids_sil = processing.initialize_vids(
-            params, datadict, 0, {}, pathonly=True, vidkey="viddir_sil"
-        )
+        vids_sil = {}
+        for e in range(num_experiments):
+            vids_sil = processing.initialize_vids(
+                params, datadict, e, vids_sil, pathonly=True, vidkey="viddir_sil"
+            )
         valid_params_sil = deepcopy(valid_params)
         valid_params_sil["vidreaders"] = vids_sil
         valid_params_sil["norm_im"] = False

--- a/dannce/engine/run/inference.py
+++ b/dannce/engine/run/inference.py
@@ -397,9 +397,7 @@ def infer_sdannce(
         params["max_num_samples"] if params["max_num_samples"] != "max" else n_frames
     )
 
-    # s-DANNCE inference processes individual samples, so we iterate over sample indices
-    # not batch indices like regular DANNCE does
-    pbar = tqdm(range(0, min(max_num_sample, n_frames), bs))
+    pbar = tqdm(range(start_ind, end_ind))
     for idx, i in enumerate(pbar):
 
         if (i - start_ind) % 1000 == 0 and i != start_ind:

--- a/dannce/engine/trainer/dannce_trainer.py
+++ b/dannce/engine/trainer/dannce_trainer.py
@@ -333,7 +333,9 @@ class DANNCETrainer(BaseTrainer):
             )
             volumes = volumes.permute(0, 4, 1, 2, 3)
             aux = aux if aux is None else aux.permute(0, 4, 1, 2, 3)
-            keypoints_3d_gt = keypoints_3d_gt.repeat(self.aug_bs, 1, 1)
+            keypoints_3d_gt = keypoints_3d_gt.repeat_interleave(
+                copies_per_sample, dim=0
+            )
             if sample_ids is not None:
                 sample_ids = [
                     sample_id

--- a/dannce/engine/trainer/posegcn_trainer.py
+++ b/dannce/engine/trainer/posegcn_trainer.py
@@ -66,10 +66,8 @@ class SDANNCETrainer(DANNCETrainer):
             aux = aux if aux is None else aux.permute(0, 4, 1, 2, 3)
 
             # update ground truth
-            keypoints_3d_gt = (
-                keypoints_3d_gt.repeat(self.aug_bs // self.per_batch_sample, 1, 1, 1)
-                .transpose(1, 0)
-                .flatten(0, 1)
+            keypoints_3d_gt = keypoints_3d_gt.repeat_interleave(
+                copies_per_sample, dim=0
             )
             if sample_ids is not None:
                 sample_ids = [

--- a/dannce/engine/utils/augmentation.py
+++ b/dannce/engine/utils/augmentation.py
@@ -33,11 +33,13 @@ def random_rotate(X, y_3d, aux=None):
 
 
 def apply_random_transforms(volumes, grids, aux=None):
-    # Dynamically compute grid dimensions from grids shape [batch_size, nvox**3, 3]
-    batch_size = grids.shape[0]
-    nvox_cubed = grids.shape[1]
-    nvox = int(round(nvox_cubed ** (1/3)))
-    grids = grids.reshape(batch_size, nvox, nvox, nvox, 3)
+    nvox = int(round(grids.shape[1] ** (1 / 3)))
+    if nvox ** 3 != grids.shape[1]:
+        raise ValueError(
+            f"Expected a cubic voxel grid, got {grids.shape[1]} grid centers."
+        )
+
+    grids = grids.reshape(grids.shape[0], nvox, nvox, nvox, 3)
 
     volumes, grids, aux = random_rotate(volumes, grids, aux)
     grids = grids.reshape(grids.shape[0], -1, 3)
@@ -45,6 +47,9 @@ def apply_random_transforms(volumes, grids, aux=None):
 
 
 def construct_augmented_batch(volumes, grids, aux=None, copies_per_sample=1):
+    if copies_per_sample < 1:
+        raise ValueError("copies_per_sample must be at least 1")
+
     copies = []
     n_samples = volumes.shape[0]
     for i in range(n_samples):

--- a/dannce/interface.py
+++ b/dannce/interface.py
@@ -139,12 +139,18 @@ def dannce_predict(params: Dict):
         params, "dannce"
     )
     # Check if this is an s-DANNCE model or regular DANNCE model  
-    if hasattr(model, 'pose_generator') or (hasattr(model, 'module') and hasattr(model.module, 'pose_generator')):  
-        # This is an s-DANNCE model  
-        inference.infer_sdannce(predict_generator, params, {}, model, partition, device)  
-    else:  
-        # This is a regular DANNCE model  
-        inference.infer_dannce(predict_generator, params, model, partition, device, params["n_channels_out"])  
+    if hasattr(model, "pose_generator") or (
+        hasattr(model, "module") and hasattr(model.module, "pose_generator")
+    ):
+        # This is an s-DANNCE model
+        inference.infer_sdannce(
+            predict_generator, params, {}, model, partition, device
+        )
+    else:
+        # This is a regular DANNCE model
+        inference.infer_dannce(
+            predict_generator, params, model, partition, device, params["n_channels_out"]
+        )
       
     predict_generator.close_all_readers()
 


### PR DESCRIPTION
### Motivation
- Fix off-by-one and final-batch sizing issues when splitting samples across GPUs to avoid over-requesting frames.  
- Make augmentation utilities and dataset generators more robust and consistent when using torchvision transforms and different dtypes/shapes.  
- Improve robustness of multi-GPU submission/merge logic to handle empty prediction dirs, test-mode returns, and missing files.  
- Harden temporal chunk preparation and dataset-serving utilities against edge cases (empty selections, non-cubic grids, clipped requests).

### Description
- Multi-GPU handler: compute per-batch sizes with `np.minimum` and use `batch_sizes` for `max_num_samples`, treat any existing prediction files (`len > 0`) as finished, skip missing predict dirs, and return `(batch_params, cmd)` in test mode while preserving previous behavior for real submissions.  
- Submission flows: update callers in `inference`/`sdannce_inference` to accept test-mode tuple returns and only use `job_id` when a real job id is returned.  
- Dataset / augmentation: switch to explicit `torchvision.transforms` `affine` calls with interpolation and explicit args in `random_continuous_rotation`, preserve original shapes via saved shape tuples, and use `repeat_interleave` where appropriate when expanding augmented ground-truth.  
- COM dataset generator: add `_group_list_ids` to group sample IDs by batch, support `augment_shift`, perform dtype-preserving array allocations, implement `random_shift` integration, and ensure augmentation pipeline converts back to original dtypes.  
- Augmentation utils: validate cubic voxel grids in `apply_random_transforms`, raise for invalid `copies_per_sample`, and guard `construct_augmented_batch` against invalid `copies_per_sample`.  
- Temporal processing and serving: handle empty chunk lists in `get_chunks`, add downsample support and clipping with warnings when requested temporal/unlabeled/support chunk counts exceed availability, return early on empty sample indices, and deduplicate/retain ordering when computing unique indices in `prepare_temporal_seqs`.  
- serve_data and preprocessing: consolidate chunk maps in `prepend_experiment` into `params['chunks']`, ensure video reader dictionaries (`vids`, `vids_sil`) are initialized for all experiments, and adapt outputs for downstream callers.  
- Loss and trainers: generalize `compute_mask_nan_loss` to use provided loss function, robustify `ConsistencyLoss` grouping logic and early-return for degenerate inputs, and fix augmented-ground-truth repetition using `repeat_interleave` in trainers.  
- Miscellaneous: formatting/refactor and small defensive checks across multiple modules (`__init__`, `processing.py`, `inference.py`, `interface.py`).

### Testing
- Ran basic automated smoke tests invoking `MultiGpuHandler.submit_com_predict_multi_gpu` and `submit_dannce_predict_multi_gpu` in `test=True` mode to verify they return `(batch_params, cmd)` and do not submit jobs; these succeeded.  
- Executed the project's automated unit tests via `pytest -q` against the modified modules; the test suite completed without failures.  
- Ran small integration smoke checks for the augmentation/data pipeline (creating small synthetic batches through `construct_augmented_batch`, `random_continuous_rotation`, and `COMDatasetFromMem` `__getitem__`) and verified outputs shape/dtype consistency; these succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d0366de5548320abcdaf2992a500e8)